### PR TITLE
Standardize scale affects minimizer convergence

### DIFF
--- a/nrefocus/iface/base.py
+++ b/nrefocus/iface/base.py
@@ -78,13 +78,14 @@ class Refocus(ABC):
 
     def autofocus(self, interval, metric="average gradient", minimizer="lmfit",
                   roi=None, minimizer_kwargs=None, ret_grid=False,
-                  ret_field=False):
+                  ret_field=False, convert_interval_to_pix=False):
         """Autofocus the initial field
 
         Parameters
         ----------
         interval: tuple of floats
-            Approximate interval to search for optimal focus [m]
+            Approximate interval to search for optimal focus [m].
+            Will be converted to pixel values.
         metric: str
             - "average gradient" : average gradient metric of amplitude
             - "rms contrast" : RMS contrast of phase data
@@ -124,6 +125,9 @@ class Refocus(ABC):
         # flip interval for user convenience
         if interval[0] > interval[1]:
             interval = (interval[1], interval[0])
+        if convert_interval_to_pix:
+            # converted interval to pixel values
+            interval = tuple(i/self.pixel_size for i in interval)
 
         # construct the correct ROI
         if (isinstance(roi, (list, tuple))

--- a/tests/test_2d_autofocus.py
+++ b/tests/test_2d_autofocus.py
@@ -25,6 +25,26 @@ def test_2d_autofocus_cell_helmholtz_average_gradient():
                        atol=0)
 
 
+def test_2d_autofocus_cell_helmholtz_average_gradient_convert_interval():
+    rf = nrefocus.iface.RefocusNumpy(field=load_cell("HL60_field.zip"),
+                                     wavelength=647e-9,
+                                     pixel_size=0.139e-6,
+                                     kernel="helmholtz",
+                                     )
+
+    # attempt to autofocus with standard arguments
+    d = rf.autofocus(metric="average gradient",
+                     minimizer="lmfit",
+                     interval=(-5e-6, 5e-6),
+                     convert_interval_to_pix=True)
+    assert np.allclose(d, -8.781356558557544e-07, atol=0)
+
+    nfield = rf.propagate(d)
+    assert np.allclose(nfield[10, 10],
+                       1.0455603934920419 - 0.020475662236633177j,
+                       atol=0)
+
+
 def test_2d_autofocus_return_field():
     rf = nrefocus.iface.RefocusNumpy(field=load_cell("HL60_field.zip"),
                                      wavelength=647e-9,
@@ -38,7 +58,7 @@ def test_2d_autofocus_return_field():
         minimizer="lmfit",
         interval=(-5e-6, 5e-6),
         ret_field=True,
-        )
+    )
 
     nfield2 = rf.propagate(d)
     assert np.all(nfield == nfield2)
@@ -58,7 +78,7 @@ def test_2d_autofocus_return_grid_field():
         interval=(-5e-6, 5e-6),
         ret_grid=True,
         ret_field=True,
-        )
+    )
 
     idx_metric_min = np.argmin(mgrid)
     idx_distance = np.argmin(np.abs(dgrid - d))
@@ -87,5 +107,13 @@ def test_2d_autofocus_small_interval():
     rf.autofocus(
         metric="average gradient",
         minimizer="lmfit",
-        interval=(0, 1.9*wavelength),
-        )
+        interval=(0, 1.9 * wavelength),
+    )
+
+
+if __name__ == "__main__":
+    # Run all tests
+    loc = locals()
+    for key in list(loc.keys()):
+        if key.startswith("test_") and hasattr(loc[key], "__call__"):
+            loc[key]()


### PR DESCRIPTION
As described in #14, there seems to be a bug related to the minimizer `interval` parameter. This might be fixed by dividing it by the pixel size.