### PR TITLE
3d array compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.7.0
+ - feat: make nrefocus compatible with n-dim arrays (#23, #25)
 0.6.0
  - feat: CuPy Refocus interface (#24)
  - setup: migrate to pyproject.toml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ This is the documentaion of nrefocus version |release|.
    :caption: Contents:
 
    sec_introduction
-   sec_ndarray_backend
+   sec_getting_started
    sec_theory
    sec_examples
    sec_code_reference

--- a/docs/sec_3d_stacks.rst
+++ b/docs/sec_3d_stacks.rst
@@ -1,0 +1,33 @@
+=========
+3D stacks
+=========
+
+.. _sec_3d_stacks:
+
+Since version 0.7.0, the :class:`.RefocusNumpy`, :class:`.RefocusPyFFTW` and
+:class:`.RefocusCupy` interfaces accept either a single 2D field shaped
+``(y, x)`` or a stack shaped ``(..., y, x)`` (for example ``(n, y, x)``).
+The last two axes are always interpreted as the spatial axes and any leading
+axes are treated as batch dimensions. If you pass an
+``n``-dimensional input, you get an output array with the same
+``n``-dimensional shape.
+
+.. code-block:: python
+
+    import numpy as np
+    import nrefocus
+
+    # stack of complex 2D fields: (n, y, x)
+    field = (np.random.randn(4, 128, 96) + 1j*np.random.randn(4, 128, 96)
+             ).astype(np.complex128)
+
+    pixel_size = 1e-6
+    rf = nrefocus.RefocusNumpy(
+        field=field,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        padding=True,
+    )
+    refocused = rf.propagate(distance=2.13 * pixel_size)
+    print(refocused.shape)  # (4, 128, 96)

--- a/docs/sec_3d_stacks.rst
+++ b/docs/sec_3d_stacks.rst
@@ -1,8 +1,8 @@
+.. _sec_3d_stacks:
+
 =========
 3D stacks
 =========
-
-.. _sec_3d_stacks:
 
 Since version 0.7.0, the :class:`.RefocusNumpy`, :class:`.RefocusPyFFTW` and
 :class:`.RefocusCupy` interfaces accept either a single 2D field shaped
@@ -11,6 +11,12 @@ The last two axes are always interpreted as the spatial axes and any leading
 axes are treated as batch dimensions. If you pass an
 ``n``-dimensional input, you get an output array with the same
 ``n``-dimensional shape.
+
+.. admonition:: `nrefocus.refocus_stack`
+
+	The convenience function `nrefocus.refocus_stack` may act strangely with a 3D
+	input for now. This is expected to be fixed/removed in future.
+
 
 .. code-block:: python
 

--- a/docs/sec_3d_stacks.rst
+++ b/docs/sec_3d_stacks.rst
@@ -14,8 +14,10 @@ axes are treated as batch dimensions. If you pass an
 
 .. admonition:: `nrefocus.refocus_stack`
 
-	The convenience function `nrefocus.refocus_stack` may act strangely with a 3D
-	input for now. This is expected to be fixed/removed in future.
+	The convenience functions `nrefocus.refocus_stack` and
+	`nrefocus.autofocus_stack` may be removed in the
+	future, as  `nrefocus` now accepts in 3D data. See
+	`Issue #28 <https://github.com/RI-imaging/nrefocus/issues/28>`_
 
 
 .. code-block:: python

--- a/docs/sec_code_reference.rst
+++ b/docs/sec_code_reference.rst
@@ -9,6 +9,9 @@ Refocus interface
 `Refocus` is a user-convenient interface for numerical refocusing.
 Each class implements refocusing for a specific dimensionality (1D or
 2D fields) using a specific method for refocusing (e.g. numpy FFT or FFTW).
+For 2D interfaces, inputs can be ``(y, x)`` or ``(..., y, x)``; when users
+pass an ``n``-dimensional input, the output array keeps that same
+``n``-dimensional shape.
 
 .. autofunction:: nrefocus.get_best_interface
 

--- a/docs/sec_examples.rst
+++ b/docs/sec_examples.rst
@@ -8,3 +8,4 @@ Examples
 
 .. fancy_include:: refocus_cell.py
 .. fancy_include:: compare_metrics.py
+.. fancy_include:: refocus_stack.py

--- a/docs/sec_getting_started.rst
+++ b/docs/sec_getting_started.rst
@@ -1,0 +1,12 @@
+===============
+Getting started
+===============
+
+.. _sec_getting_started:
+
+.. toctree::
+  :maxdepth: 2
+
+  sec_getting_started_basics
+  sec_ndarray_backend
+  sec_3d_stacks

--- a/docs/sec_getting_started_basics.rst
+++ b/docs/sec_getting_started_basics.rst
@@ -1,0 +1,34 @@
+===================
+Basics of qpretrieve
+===================
+
+.. _sec_getting_started_basics:
+
+This section gives a minimal example for numerical refocussing of a single 2D
+complex field with ``nrefocus``.
+
+If you want to use the GPU via CuPy, see :ref:`sec_doc_ndarray_backend`.
+If you want to refocus stacks shaped ``(..., y, x)``, see :ref:`sec_3d_stacks`.
+
+.. code-block:: python
+
+    import numpy as np
+    import nrefocus
+
+    # A single complex 2D field: (y, x)
+    ny, nx = 128, 96
+    field = (np.random.randn(ny, nx) + 1j*np.random.randn(ny, nx)
+             ).astype(np.complex128)
+
+    pixel_size = 1e-6
+    # you can instead use `RefocusPyFFTW` or `RefocusCupy` if you want
+    rf = nrefocus.RefocusNumpy(
+        field=field,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        padding=True,
+    )
+
+    refocused = rf.propagate(distance=2.13 * pixel_size)
+    print(refocused.shape)  # (128, 96)

--- a/docs/sec_getting_started_basics.rst
+++ b/docs/sec_getting_started_basics.rst
@@ -1,6 +1,6 @@
-===================
-Basics of qpretrieve
-===================
+==================
+Basics of nrefocus
+==================
 
 .. _sec_getting_started_basics:
 

--- a/docs/sec_ndarray_backend.rst
+++ b/docs/sec_ndarray_backend.rst
@@ -1,7 +1,7 @@
+.. _sec_doc_ndarray_backend:
+
 Setting the NDArray Backend
 ===========================
-
-.. _sec_doc_ndarray_backend:
 
 Since version 0.6.0, `nrefocus` allows the user to leverage their CUDA GPU
 via the :class:`.RefocusCupy` refocus interface and the ``CuPy`` library.

--- a/examples/refocus_stack.py
+++ b/examples/refocus_stack.py
@@ -1,0 +1,35 @@
+"""Refocus a stack of 2D fields (3D array input).
+
+This example shows how to refocus a stack shaped (n, y, x).  nrefocus
+interprets the last two axes as spatial axes and broadcasts over any leading
+"batch" axes.
+
+"""
+import numpy as np
+
+import nrefocus
+
+rng = np.random.default_rng(0)
+
+# Synthetic complex field stack: (n, y, x)
+n, ny, nx = 5, 128, 96
+amp = 1 + 0.1 * rng.normal(size=(n, ny, nx))
+pha = 0.3 * rng.normal(size=(n, ny, nx))
+field = amp * np.exp(1j * pha)
+
+pixel_size = 1e-6
+dist = 2.13 * pixel_size
+
+# CPU (NumPy) refocus of the entire stack in one call
+rf = nrefocus.RefocusNumpy(
+    field=field,
+    wavelength=8.25 * pixel_size,
+    pixel_size=pixel_size,
+    medium_index=1.533,
+    distance=0,
+    kernel="helmholtz",
+    padding=True,
+)
+refocused = rf.propagate(distance=dist)
+print("nrefocus now accepts stacks of 2D arrays (3D input)!\n"
+      "Input shape:", field.shape, "| Output shape-> ", refocused.shape)

--- a/nrefocus/iface/base.py
+++ b/nrefocus/iface/base.py
@@ -236,8 +236,12 @@ class Refocus(ABC):
         twopi = 2 * xp.pi
 
         km = twopi * nm / res
-        kx = (xp.fft.fftfreq(self.fft_origin.shape[0]) * twopi).reshape(-1, 1)
-        ky = (xp.fft.fftfreq(self.fft_origin.shape[1]) * twopi).reshape(1, -1)
+        # Spatial axes are always the last two axes: (..., y, x).
+        # This allows refocusing batched stacks such as (n, y, x).
+        ny = self.fft_origin.shape[-2]
+        nx = self.fft_origin.shape[-1]
+        kx = (xp.fft.fftfreq(ny) * twopi).reshape(-1, 1)
+        ky = (xp.fft.fftfreq(nx) * twopi).reshape(1, -1)
         fstemp = self._evaluate_kernel(kx, ky, km, d)
         return fstemp
 

--- a/nrefocus/iface/base.py
+++ b/nrefocus/iface/base.py
@@ -14,8 +14,13 @@ class Refocus(ABC):
         r"""
         Parameters
         ----------
-        field: 2d complex-valued ndarray
-            Input field to be refocused
+        field: complex-valued ndarray
+            n-dimensional input field to be refocused.
+            1D ``(x)``, 2D ``(y, x)`` and 3D ``(z, y, x)``
+            (e.g. 3D stack of 2D images) shapes are accepted. For data >3D,
+            the final two dimensions are always assumed to be spatial.
+            If an ``n``-dimensional input is provided, the output keeps
+            the same shape.
         wavelength: float
             Wavelength of the used light [m]
         pixel_size: float
@@ -61,15 +66,16 @@ class Refocus(ABC):
 
         Parameters
         ----------
-        field: 2d complex-valued ndarray
-            Input field to be refocused
+        field: complex-valued ndarray
+            Input field to be refocused, shaped ``(y, x)`` or
+            ``(..., y, x)``.
         padding: bool
             Whether to perform boundary-padding with linear ramp
 
         Returns
         -------
-        fft_field0: 2d complex-valued ndarray
-            Fourier transform the initial field
+        fft_field0: complex-valued ndarray
+            Fourier transform of the initial field
 
         Notes
         -----
@@ -256,8 +262,9 @@ class Refocus(ABC):
 
         Returns
         -------
-        refocused_field: 2d ndarray
-            Initial field refocused at `distance`
+        refocused_field: ndarray
+            Initial field refocused at `distance`, with the same shape as
+            the input field.
 
         Notes
         -----

--- a/nrefocus/iface/base.py
+++ b/nrefocus/iface/base.py
@@ -246,8 +246,8 @@ class Refocus(ABC):
         # This allows refocusing batched stacks such as (n, y, x).
         ny = self.fft_origin.shape[-2]
         nx = self.fft_origin.shape[-1]
-        kx = (xp.fft.fftfreq(nx) * twopi).reshape(-1, 1)
-        ky = (xp.fft.fftfreq(ny) * twopi).reshape(1, -1)
+        kx = (xp.fft.fftfreq(nx) * twopi).reshape(1, -1)
+        ky = (xp.fft.fftfreq(ny) * twopi).reshape(-1, 1)
         fstemp = self._evaluate_kernel(kx, ky, km, d)
         return fstemp
 

--- a/nrefocus/iface/base.py
+++ b/nrefocus/iface/base.py
@@ -246,8 +246,8 @@ class Refocus(ABC):
         # This allows refocusing batched stacks such as (n, y, x).
         ny = self.fft_origin.shape[-2]
         nx = self.fft_origin.shape[-1]
-        kx = (xp.fft.fftfreq(ny) * twopi).reshape(-1, 1)
-        ky = (xp.fft.fftfreq(nx) * twopi).reshape(1, -1)
+        kx = (xp.fft.fftfreq(nx) * twopi).reshape(-1, 1)
+        ky = (xp.fft.fftfreq(ny) * twopi).reshape(1, -1)
         fstemp = self._evaluate_kernel(kx, ky, km, d)
         return fstemp
 

--- a/nrefocus/iface/rf_cupy.py
+++ b/nrefocus/iface/rf_cupy.py
@@ -42,7 +42,8 @@ class RefocusCupy(Refocus):
         if padding:
             field_gpu = pad.pad_add(field_gpu)
         with sp.fft.set_backend(cufft):
-            return sp.fft.fft2(field_gpu)
+            # Allow stacks shaped (..., y, x) by transforming the last axes.
+            return sp.fft.fft2(field_gpu, axes=(-2, -1))
 
     def propagate(self, distance):
         if not xp.is_cupy():
@@ -56,7 +57,7 @@ class RefocusCupy(Refocus):
         fft_gpu = xp.asarray(self.fft_origin * fft_kernel)
 
         with sp.fft.set_backend(cufft):
-            refoc = sp.fft.ifft2(fft_gpu)
+            refoc = sp.fft.ifft2(fft_gpu, axes=(-2, -1))
         if self.padding:
             refoc = pad.pad_rem(refoc)
         return refoc

--- a/nrefocus/iface/rf_numpy.py
+++ b/nrefocus/iface/rf_numpy.py
@@ -32,11 +32,12 @@ class RefocusNumpy(Refocus):
         """
         if padding:
             field = pad.pad_add(field)
-        return xp.fft.fft2(field)
+        # Allow stacks shaped (..., y, x) by always transforming the last axes.
+        return xp.fft.fft2(field, axes=(-2, -1))
 
     def propagate(self, distance):
         fft_kernel = self.get_kernel(distance=distance)
-        refoc = xp.fft.ifft2(self.fft_origin * fft_kernel)
+        refoc = xp.fft.ifft2(self.fft_origin * fft_kernel, axes=(-2, -1))
         if self.padding:
             refoc = pad.pad_rem(refoc)
         return refoc

--- a/nrefocus/iface/rf_pyfftw.py
+++ b/nrefocus/iface/rf_pyfftw.py
@@ -40,17 +40,18 @@ class RefocusPyFFTW(Refocus):
         """
         if padding:
             field = pad.pad_add(field)
+        spatial_axes = (field.ndim - 2, field.ndim - 1)
         # compute the input Fourier transform
         origin = pyfftw.empty_aligned(field.shape, dtype='complex128')
         fft_origin = pyfftw.empty_aligned(field.shape, dtype='complex128')
-        fft_obj = pyfftw.FFTW(origin, fft_origin, axes=(0, 1))
+        fft_obj = pyfftw.FFTW(origin, fft_origin, axes=spatial_axes)
         origin[:] = field
         fft_obj()
 
         # now setup the backward transform
         inv_input = pyfftw.empty_aligned(field.shape, dtype='complex128')
         inv_output = pyfftw.empty_aligned(field.shape, dtype='complex128')
-        self._ifft_obj = pyfftw.FFTW(inv_input, inv_output, axes=(0, 1),
+        self._ifft_obj = pyfftw.FFTW(inv_input, inv_output, axes=spatial_axes,
                                      direction="FFTW_BACKWARD",
                                      flags=["FFTW_DESTROY_INPUT"],
                                      threads=mp.cpu_count())
@@ -58,8 +59,9 @@ class RefocusPyFFTW(Refocus):
 
     def propagate(self, distance):
         fft_kernel = self.get_kernel(distance=distance)
-        xp.multiply(self.fft_origin, fft_kernel,
-                    out=self._ifft_obj.input_array)
+        # `out=` does not permit broadcasting; explicitly assign the
+        # broadcasted product into the input buffer.
+        self._ifft_obj.input_array[:] = self.fft_origin * fft_kernel
         refoc = self._ifft_obj()
         if self.padding:
             refoc = pad.pad_rem(refoc)

--- a/nrefocus/iface/rf_pyfftw.py
+++ b/nrefocus/iface/rf_pyfftw.py
@@ -1,6 +1,5 @@
 import multiprocessing as mp
 
-from .._ndarray_backend import xp
 import pyfftw
 
 from .. import pad

--- a/nrefocus/pad.py
+++ b/nrefocus/pad.py
@@ -68,20 +68,49 @@ def pad_add(av, size=None, stlen=10):
         Padded array `av` with pads appended to right and bottom.
     """
     if size is None:
-        size = list()
-        for s in av.shape:
-            size.append(int(2*s))
+        if len(av.shape) == 1:
+            size = [int(2 * av.shape[0])]
+        else:
+            # For stacks (..., y, x), pad only spatial axes.
+            size = [int(2 * av.shape[-2]), int(2 * av.shape[-1])]
     elif not hasattr(size, "__len__"):
-        size = [size]
+        if len(av.shape) == 1:
+            size = [size]
+        else:
+            size = [size, size]
 
-    assert len(av.shape) in [1, 2], "Only 1D and 2D arrays!"
-    assert len(av.shape) == len(
-        size), "`size` must have same length as `av.shape`!"
+    if len(av.shape) == 1:
+        assert len(size) == 1
+        return _pad_add_1d(av, size, stlen)
+
+    # 2D or stack of 2D: (..., y, x)
+    if len(size) == len(av.shape):
+        # Backwards-compatible input: ignore leading dims but require
+        # they are not being "padded" to a different size.
+        assert list(size[:-2]) == list(av.shape[:-2]), (
+            "For stacks, only the last two axes can be padded; leading "
+            "sizes must match `av.shape`."
+        )
+        size = list(size[-2:])
+
+    assert len(size) == 2, (
+        "`size` must be a scalar or a tuple/list of length 2 for 2D inputs "
+        "or stacks (..., y, x)."
+    )
 
     if len(av.shape) == 2:
         return _pad_add_2d(av, size, stlen)
-    else:
-        return _pad_add_1d(av, size, stlen)
+
+    # Stack: pad each 2D slice independently to preserve legacy behavior
+    # (i.e. same results as calling pad_add on each slice).
+    lead_shape = av.shape[:-2]
+    ny, nx = av.shape[-2], av.shape[-1]
+    out_y, out_x = int(size[0]), int(size[1])
+    av2 = av.reshape((-1, ny, nx))
+    out2 = xp.empty((av2.shape[0], out_y, out_x), dtype=av.dtype)
+    for i in range(av2.shape[0]):
+        out2[i] = _pad_add_2d(av2[i], [out_y, out_x], stlen)
+    return out2.reshape(lead_shape + (out_y, out_x))
 
 
 def _pad_add_1d(av, size, stlen):
@@ -162,18 +191,38 @@ def pad_rem(pv, size=None):
         Padded array `av` with pads appended to right and bottom.
     """
     if size is None:
-        size = list()
-        for s in pv.shape:
-            assert s % 2 == 0, "Uneven size; specify correct size of output!"
-            size.append(int(s/2))
+        if len(pv.shape) == 1:
+            assert pv.shape[0] % 2 == 0, (
+                "Uneven size; specify correct size of output!"
+            )
+            size = [int(pv.shape[0] / 2)]
+        else:
+            # For stacks (..., y, x), remove padding only on spatial axes.
+            assert pv.shape[-2] % 2 == 0 and pv.shape[-1] % 2 == 0, (
+                "Uneven size; specify correct size of output!"
+            )
+            size = [int(pv.shape[-2] / 2), int(pv.shape[-1] / 2)]
     elif not hasattr(size, "__len__"):
-        size = [size]
+        if len(pv.shape) == 1:
+            size = [size]
+        else:
+            size = [size, size]
 
-    assert len(pv.shape) in [1, 2], "Only 1D and 2D arrays!"
-    assert len(pv.shape) == len(
-        size), "`size` must have same length as `av.shape`!"
-
-    if len(pv.shape) == 2:
-        return pv[:size[0], :size[1]]
-    else:
+    if len(pv.shape) == 1:
+        assert len(size) == 1
         return pv[:size[0]]
+
+    if len(size) == len(pv.shape):
+        assert list(size[:-2]) == list(pv.shape[:-2]), (
+            "For stacks, only the last two axes can be unpadded; leading "
+            "sizes must match `pv.shape`."
+        )
+        size = list(size[-2:])
+
+    assert len(size) == 2, (
+        "`size` must be a scalar or a tuple/list of length 2 for 2D inputs "
+        "or stacks (..., y, x)."
+    )
+
+    # Works for 2D and stacks: keep leading axes, crop last two.
+    return pv[..., :size[0], :size[1]]

--- a/nrefocus/propg.py
+++ b/nrefocus/propg.py
@@ -11,12 +11,13 @@ _cpu_count = mp.cpu_count()
 
 
 def refocus(field, d, nm, res, method="helmholtz", padding=True):
-    """Refocus a 1D or 2D field
+    """Refocus a 1D field or a 2D field / stack of 2D fields
 
     Parameters
     ----------
-    field : 1d or 2d array
-        1D or 2D background corrected electric field (Ex/BEx)
+    field : 1d array or (..., y, x) array
+        Background corrected electric field (Ex/BEx). For stacks, the last
+        two axes are interpreted as spatial axes.
     d : float
         Distance to be propagated in pixels (negative for backwards)
     nm : float
@@ -51,11 +52,11 @@ def refocus(field, d, nm, res, method="helmholtz", padding=True):
     if fshape == 1:
         # 1D field
         rfcls = iface.RefocusNumpy1D
-    elif fshape == 2:
-        # 2D field
+    elif fshape >= 2:
+        # 2D field or stack (..., y, x)
         rfcls = iface.RefocusNumpy
     else:
-        raise AssertionError("Dimension of `field` must be 1 or 2.")
+        raise AssertionError(f"Unexpected dimension of `field` ({fshape}).")
 
     # use a made-up pixel size so we can use the new `Refocus` interface
     pixel_size = 1e-6

--- a/tests/test_cupy_gpu/test_refocus_cupy.py
+++ b/tests/test_cupy_gpu/test_refocus_cupy.py
@@ -25,3 +25,40 @@ def test_2d_refocus1_cupy(set_ndarray_backend_to_cupy):
     reference = np.loadtxt(data_path / "test_2d_refocus1.txt")
     assert np.allclose(np.array(refocused_cpu).flatten().view(float),
                        reference)
+
+
+@skip_if_missing("cupy")
+def test_refocus_cupy_stack_matches_per_slice(set_ndarray_backend_to_cupy):
+    rng = np.random.default_rng(0)
+    stack = (rng.normal(size=(5, 16, 12)) + 1j * rng.normal(size=(5, 16, 12))
+             ).astype(np.complex128)
+
+    pixel_size = 1e-6
+    dist = 2.13 * pixel_size
+
+    rf_stack = nrefocus.RefocusCupy(
+        field=stack,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        distance=0,
+        kernel="helmholtz",
+        padding=True,
+    )
+    out_stack = rf_stack.propagate(distance=dist).get()
+
+    out_expected = np.empty_like(stack)
+    for i in range(stack.shape[0]):
+        rf = nrefocus.RefocusCupy(
+            field=stack[i],
+            wavelength=8.25 * pixel_size,
+            pixel_size=pixel_size,
+            medium_index=1.533,
+            distance=0,
+            kernel="helmholtz",
+            padding=True,
+        )
+        out_expected[i] = rf.propagate(distance=dist).get()
+
+    assert out_stack.shape == stack.shape
+    assert np.allclose(out_stack, out_expected, rtol=1e-12, atol=1e-12)

--- a/tests/test_refocus_numpy.py
+++ b/tests/test_refocus_numpy.py
@@ -23,6 +23,42 @@ def test_2d_refocus1():
     assert np.allclose(np.array(refocused).flatten().view(float), reference)
 
 
+def test_refocus_numpy_stack_matches_per_slice():
+    rng = np.random.default_rng(0)
+    stack = (rng.normal(size=(5, 16, 12)) + 1j * rng.normal(size=(5, 16, 12))
+             ).astype(np.complex128)
+
+    pixel_size = 1e-6
+    dist = 2.13 * pixel_size
+
+    rf_stack = nrefocus.RefocusNumpy(
+        field=stack,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        distance=0,
+        kernel="helmholtz",
+        padding=True,
+    )
+    out_stack = rf_stack.propagate(distance=dist)
+
+    out_expected = np.empty_like(stack)
+    for i in range(stack.shape[0]):
+        rf = nrefocus.RefocusNumpy(
+            field=stack[i],
+            wavelength=8.25 * pixel_size,
+            pixel_size=pixel_size,
+            medium_index=1.533,
+            distance=0,
+            kernel="helmholtz",
+            padding=True,
+        )
+        out_expected[i] = rf.propagate(distance=dist)
+
+    assert out_stack.shape == stack.shape
+    assert np.allclose(out_stack, out_expected, rtol=1e-12, atol=1e-12)
+
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()

--- a/tests/test_refocus_numpy.py
+++ b/tests/test_refocus_numpy.py
@@ -59,6 +59,26 @@ def test_refocus_numpy_stack_matches_per_slice():
     assert np.allclose(out_stack, out_expected, rtol=1e-12, atol=1e-12)
 
 
+def test_refocus_numpy_nonsquare_nopadding():
+    rng = np.random.default_rng(0)
+    stack = (rng.normal(size=(5, 16, 12)) + 1j * rng.normal(size=(5, 16, 12))
+             ).astype(np.complex128)
+    pixel_size = 1e-6
+    dist = 2.13 * pixel_size
+
+    rf_stack = nrefocus.RefocusNumpy(
+        field=stack,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        distance=0,
+        kernel="helmholtz",
+        padding=False,
+    )
+    out_stack = rf_stack.propagate(distance=dist)
+
+    assert out_stack.shape == stack.shape
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()

--- a/tests/test_refocus_numpy.py
+++ b/tests/test_refocus_numpy.py
@@ -4,21 +4,20 @@ import numpy as np
 
 import nrefocus
 
-
 data_path = pathlib.Path(__file__).parent / "data"
 
 
 def test_2d_refocus1():
     pixel_size = 1e-6
     rf = nrefocus.RefocusNumpy(field=np.arange(256).reshape(16, 16),
-                               wavelength=8.25*pixel_size,
+                               wavelength=8.25 * pixel_size,
                                pixel_size=pixel_size,
                                medium_index=1.533,
                                distance=0,
                                kernel="helmholtz",
                                padding=False)
 
-    refocused = rf.propagate(distance=2.13*pixel_size)
+    refocused = rf.propagate(distance=2.13 * pixel_size)
     reference = np.loadtxt(data_path / "test_2d_refocus1.txt")
     assert np.allclose(np.array(refocused).flatten().view(float), reference)
 
@@ -78,6 +77,7 @@ def test_refocus_numpy_nonsquare_nopadding():
     out_stack = rf_stack.propagate(distance=dist)
 
     assert out_stack.shape == stack.shape
+
 
 if __name__ == "__main__":
     # Run all tests

--- a/tests/test_refocus_pyfftw.py
+++ b/tests/test_refocus_pyfftw.py
@@ -23,6 +23,42 @@ def test_2d_refocus1():
     assert np.allclose(np.array(refocused).flatten().view(float), reference)
 
 
+def test_refocus_pyfftw_stack_matches_per_slice():
+    rng = np.random.default_rng(0)
+    stack = (rng.normal(size=(4, 16, 12)) + 1j * rng.normal(size=(4, 16, 12))
+             ).astype(np.complex128)
+
+    pixel_size = 1e-6
+    dist = 2.13 * pixel_size
+
+    rf_stack = nrefocus.RefocusPyFFTW(
+        field=stack,
+        wavelength=8.25 * pixel_size,
+        pixel_size=pixel_size,
+        medium_index=1.533,
+        distance=0,
+        kernel="helmholtz",
+        padding=True,
+    )
+    out_stack = rf_stack.propagate(distance=dist)
+
+    out_expected = np.empty_like(stack)
+    for i in range(stack.shape[0]):
+        rf = nrefocus.RefocusPyFFTW(
+            field=stack[i],
+            wavelength=8.25 * pixel_size,
+            pixel_size=pixel_size,
+            medium_index=1.533,
+            distance=0,
+            kernel="helmholtz",
+            padding=True,
+        )
+        out_expected[i] = rf.propagate(distance=dist)
+
+    assert out_stack.shape == stack.shape
+    assert np.allclose(out_stack, out_expected, rtol=1e-12, atol=1e-12)
+
+
 if __name__ == "__main__":
     # Run all tests
     loc = locals()


### PR DESCRIPTION
As discussed in #23, I want to make `nrefocus` 3d array compatible as I did with qpretrieve.

Here it is a little smarter, and "less" of a breaking change compared to `qpretrieve`. The return shape will simply be the same as the input array shape. Which makes logical sense and is just an extension of the current options of 1D and 2D inputs. It's something to think about regarding the previous breaking change in `qpretrieve`; we could make the array handling similar to this.

## todos
- [x] update changelog
- [x] make nrefocus 3d array compatible
- [x] tests and examples run with 3d inputs
- [x] back-compatible